### PR TITLE
chore: Added basic unit testing

### DIFF
--- a/assets/src/js/utils.ts
+++ b/assets/src/js/utils.ts
@@ -48,22 +48,6 @@ type WPMediaFrame = {
 };
 
 /**
- * Helper function to validate if a string is a well-formed URL.
- *
- * @param {string} str - The string to validate as a URL.
- *
- * @return {boolean} True if the string is a valid URL, false otherwise.
- */
-const isURL = ( str: string ): boolean => {
-	try {
-		new URL( str );
-		return true;
-	} catch {
-		return false;
-	}
-};
-
-/**
  * Validates if a given string is a valid URL.
  *
  * @param {string} url - The URL string to validate.
@@ -72,8 +56,8 @@ const isURL = ( str: string ): boolean => {
  */
 const isValidUrl = ( url: string ): boolean => {
 	try {
-		const parsedUrl = new URL( url );
-		return isURL( parsedUrl.href );
+		new URL( url );
+		return true;
 	} catch {
 		return false;
 	}
@@ -111,10 +95,7 @@ const getNoticeClass = ( type: NoticeType[ 'type' ] ): string => {
  * @param {number} maxLength - The maximum length of the title (default is 25).
  * @return {string} The trimmed title.
  */
-const trimTitle = ( title: string, maxLength: number = 25 ): string => {
-	if ( typeof title !== 'string' ) {
-		return '';
-	}
+const trimTitle = ( title: string = '', maxLength: number = 25 ): string => {
 	return title.length > maxLength
 		? title.substring( 0, maxLength ) + '…'
 		: title;
@@ -226,12 +207,8 @@ function getFrameProperty< T = object >( propertyPath: string ): T | undefined {
  * @param {NoticeType} detail - The detail object containing type and message.
  */
 const showSnackbarNotice = ( detail: NoticeType ): void => {
-	if ( ! detail || typeof detail !== 'object' ) {
-		return;
-	}
-
-	const type = detail?.type || 'error';
-	const message = detail?.message || '';
+	const type = detail.type || 'error';
+	const message = detail.message || '';
 
 	if ( ! message ) {
 		return;
@@ -316,7 +293,6 @@ function getAllowedMimeTypeExtensions( mimeMap: Object ): string[] {
 }
 
 export {
-	isURL,
 	isValidUrl,
 	removeTrailingSlash,
 	getNoticeClass,

--- a/inc/Utils.php
+++ b/inc/Utils.php
@@ -83,6 +83,7 @@ final class Utils {
 		}
 
 		if ( '' === $located_template ) {
+			ob_end_clean();
 			return '';
 		}
 

--- a/tests/js/utils.test.ts
+++ b/tests/js/utils.test.ts
@@ -7,7 +7,6 @@ import {
 	getAllowedMimeTypes,
 	getFrameProperty,
 	getNoticeClass,
-	isURL,
 	isValidUrl,
 	observeElement,
 	removeTrailingSlash,
@@ -17,16 +16,6 @@ import {
 } from '@/js/utils';
 
 describe( 'utils', () => {
-	describe( 'isURL', () => {
-		it( 'returns true for a valid absolute URL', () => {
-			expect( isURL( 'https://example.com/path?x=1' ) ).toBe( true );
-		} );
-
-		it( 'returns false for an invalid URL string', () => {
-			expect( isURL( 'not a url' ) ).toBe( false );
-		} );
-	} );
-
 	describe( 'isValidUrl', () => {
 		it( 'returns true for a valid URL', () => {
 			expect( isValidUrl( 'https://example.org' ) ).toBe( true );
@@ -75,6 +64,10 @@ describe( 'utils', () => {
 			expect( trimTitle( 'abcdefghijklmnopqrstuvwxyz', 5 ) ).toBe(
 				'abcde…'
 			);
+		} );
+
+		it( 'returns an empty string when title is omitted', () => {
+			expect( trimTitle() ).toBe( '' );
 		} );
 	} );
 

--- a/tests/js/utils.test.ts
+++ b/tests/js/utils.test.ts
@@ -1,0 +1,273 @@
+/**
+ * External dependencies
+ */
+import {
+	debounce,
+	getAllowedMimeTypeExtensions,
+	getAllowedMimeTypes,
+	getFrameProperty,
+	getNoticeClass,
+	isURL,
+	isValidUrl,
+	observeElement,
+	removeTrailingSlash,
+	restrictMediaFrameUploadTypes,
+	showSnackbarNotice,
+	trimTitle,
+} from '@/js/utils';
+
+describe( 'utils', () => {
+	describe( 'isURL', () => {
+		it( 'returns true for a valid absolute URL', () => {
+			expect( isURL( 'https://example.com/path?x=1' ) ).toBe( true );
+		} );
+
+		it( 'returns false for an invalid URL string', () => {
+			expect( isURL( 'not a url' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isValidUrl', () => {
+		it( 'returns true for a valid URL', () => {
+			expect( isValidUrl( 'https://example.org' ) ).toBe( true );
+		} );
+
+		it( 'returns false for malformed values', () => {
+			expect( isValidUrl( '://broken' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'removeTrailingSlash', () => {
+		it( 'removes one or more trailing slashes', () => {
+			expect( removeTrailingSlash( 'https://example.com///' ) ).toBe(
+				'https://example.com'
+			);
+		} );
+
+		it( 'keeps URLs without trailing slash unchanged', () => {
+			expect( removeTrailingSlash( 'https://example.com/path' ) ).toBe(
+				'https://example.com/path'
+			);
+		} );
+	} );
+
+	describe( 'getNoticeClass', () => {
+		it( 'maps error and warning to their dedicated classes', () => {
+			expect( getNoticeClass( 'error' ) ).toBe( 'onemedia-error-notice' );
+			expect( getNoticeClass( 'warning' ) ).toBe(
+				'onemedia-warning-notice'
+			);
+		} );
+
+		it( 'falls back to success class for other values', () => {
+			expect( getNoticeClass( 'success' ) ).toBe(
+				'onemedia-success-notice'
+			);
+		} );
+	} );
+
+	describe( 'trimTitle', () => {
+		it( 'returns the same title when below max length', () => {
+			expect( trimTitle( 'Short title', 20 ) ).toBe( 'Short title' );
+		} );
+
+		it( 'truncates and appends ellipsis when over max length', () => {
+			expect( trimTitle( 'abcdefghijklmnopqrstuvwxyz', 5 ) ).toBe(
+				'abcde…'
+			);
+		} );
+	} );
+
+	describe( 'debounce', () => {
+		beforeEach( () => {
+			jest.useFakeTimers();
+		} );
+
+		afterEach( () => {
+			jest.useRealTimers();
+		} );
+
+		it( 'only invokes the callback once with latest arguments', () => {
+			const callback = jest.fn();
+			const debounced = debounce( callback, 200 );
+
+			debounced( 'first', 1, true, {} );
+			debounced( 'second', 2, false, { value: 1 } );
+			debounced( 'third', 3, true, { value: 2 } );
+
+			expect( callback ).not.toHaveBeenCalled();
+			jest.advanceTimersByTime( 200 );
+			expect( callback ).toHaveBeenCalledTimes( 1 );
+			expect( callback ).toHaveBeenCalledWith( 'third', 3, true, {
+				value: 2,
+			} );
+		} );
+	} );
+
+	describe( 'observeElement', () => {
+		it( 'runs callback immediately when matching elements already exist', () => {
+			document.body.innerHTML = '<div class="target"></div>';
+			const onFound = jest.fn();
+
+			const observer = observeElement( '.target', onFound );
+			observer.disconnect();
+
+			expect( onFound ).toHaveBeenCalledTimes( 1 );
+			expect( onFound.mock.calls[ 0 ][ 0 ] ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'getFrameProperty', () => {
+		it( 'returns nested property when it exists', () => {
+			( window as unknown as { demo?: { value?: string } } ).demo = {
+				value: 'ok',
+			};
+
+			expect( getFrameProperty< string >( 'demo.value' ) ).toBe( 'ok' );
+		} );
+
+		it( 'returns undefined for missing or invalid paths', () => {
+			expect( getFrameProperty( '' ) ).toBeUndefined();
+			expect( getFrameProperty( 'demo.missing' ) ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'showSnackbarNotice', () => {
+		it( 'dispatches onemediaNotice with detail payload', () => {
+			const listener = jest.fn();
+			document.addEventListener(
+				'onemediaNotice',
+				listener as EventListener
+			);
+
+			showSnackbarNotice( {
+				type: 'success',
+				message: 'Saved',
+			} );
+
+			expect( listener ).toHaveBeenCalledTimes( 1 );
+			const event = listener.mock.calls[ 0 ][ 0 ] as CustomEvent;
+			expect( event.detail ).toEqual( {
+				type: 'success',
+				message: 'Saved',
+			} );
+
+			document.removeEventListener(
+				'onemediaNotice',
+				listener as EventListener
+			);
+		} );
+
+		it( 'does not dispatch when message is missing', () => {
+			const listener = jest.fn();
+			document.addEventListener(
+				'onemediaNotice',
+				listener as EventListener
+			);
+
+			showSnackbarNotice( {
+				type: 'error',
+				message: '',
+			} );
+
+			expect( listener ).not.toHaveBeenCalled();
+
+			document.removeEventListener(
+				'onemediaNotice',
+				listener as EventListener
+			);
+		} );
+	} );
+
+	describe( 'restrictMediaFrameUploadTypes', () => {
+		it( 'configures uploader filters and multipart params when uploader is ready', () => {
+			const setOption = jest.fn();
+			const uploader = {
+				settings: {
+					multipart_params: {
+						existing: 'value',
+					},
+				},
+				setOption,
+			};
+
+			const onceCallbacks: Record< string, () => void > = {};
+			const onCallbacks: Record< string, () => void > = {};
+			const observe = jest.fn();
+
+			const frame = {
+				once: jest.fn( ( event: string, cb: () => void ) => {
+					onceCallbacks[ event ] = cb;
+				} ),
+				on: jest.fn( ( event: string, cb: () => void ) => {
+					onCallbacks[ event ] = cb;
+				} ),
+				uploader: {
+					uploader: {
+						uploader,
+					},
+				},
+				state: () => ( {
+					get: () => ( {
+						observe,
+					} ),
+				} ),
+			};
+
+			(
+				window as unknown as { wp: { Uploader: { queue: unknown } } }
+			 ).wp = {
+				Uploader: {
+					queue: {
+						id: 1,
+					},
+				},
+			} as { Uploader: { queue: unknown } };
+
+			restrictMediaFrameUploadTypes(
+				frame as unknown as Parameters<
+					typeof restrictMediaFrameUploadTypes
+				>[ 0 ],
+				'jpg,png',
+				true
+			);
+
+			onceCallbacks[ 'uploader:ready' ]?.();
+			onCallbacks[ 'ready' ]?.();
+
+			expect( setOption ).toHaveBeenCalledWith( 'filters', {
+				mime_types: [ { extensions: 'jpg,png' } ],
+			} );
+			expect( setOption ).toHaveBeenCalledWith(
+				'multi_selection',
+				false
+			);
+			expect( setOption ).toHaveBeenCalledWith( 'multipart_params', {
+				existing: 'value',
+				is_onemedia_sync: true,
+			} );
+			expect( observe ).toHaveBeenCalledWith( window.wp.Uploader.queue );
+		} );
+	} );
+
+	describe( 'mime helpers', () => {
+		it( 'returns unique mime types from map values', () => {
+			expect(
+				getAllowedMimeTypes( {
+					jpg: 'image/jpeg',
+					jpeg: 'image/jpeg',
+					png: 'image/png',
+				} )
+			).toEqual( [ 'image/jpeg', 'image/png' ] );
+		} );
+
+		it( 'returns flattened extension list from pipe-delimited keys', () => {
+			expect(
+				getAllowedMimeTypeExtensions( {
+					'jpg|jpeg': 'image/jpeg',
+					png: 'image/png',
+				} )
+			).toEqual( [ 'jpg', 'jpeg', 'png' ] );
+		} );
+	} );
+} );

--- a/tests/phpunit/TestCase.php
+++ b/tests/phpunit/TestCase.php
@@ -7,7 +7,7 @@
 
 declare( strict_types = 1 );
 
-namespace rtCamp\OneMedia\Tests;
+namespace OneMedia\Tests;
 
 use WP_UnitTestCase;
 

--- a/tests/phpunit/Unit/EncryptorTest.php
+++ b/tests/phpunit/Unit/EncryptorTest.php
@@ -10,10 +10,8 @@ declare( strict_types = 1 );
 namespace OneMedia\Tests\Unit;
 
 use OneMedia\Encryptor;
+use OneMedia\Tests\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
-use rtCamp\OneMedia\Tests\TestCase;
-
-require_once dirname( __DIR__ ) . '/TestCase.php';
 
 /**
  * @covers \OneMedia\Encryptor

--- a/tests/phpunit/Unit/EncryptorTest.php
+++ b/tests/phpunit/Unit/EncryptorTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Tests for encryption helpers.
+ *
+ * @package OneMedia\Tests\Unit
+ */
+
+declare( strict_types = 1 );
+
+namespace OneMedia\Tests\Unit;
+
+use OneMedia\Encryptor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use rtCamp\OneMedia\Tests\TestCase;
+
+require_once dirname( __DIR__ ) . '/TestCase.php';
+
+/**
+ * @covers \OneMedia\Encryptor
+ */
+#[CoversClass( Encryptor::class )]
+final class EncryptorTest extends TestCase {
+	/**
+	 * Tests that encrypted values decrypt back to their original value.
+	 */
+	public function test_encrypt_and_decrypt_round_trip_value(): void {
+		$raw_value = 'https://example.com/private-media.jpg?token=abc123';
+
+		$encrypted_value = Encryptor::encrypt( $raw_value );
+
+		$this->assertIsString( $encrypted_value );
+		$this->assertNotSame( $raw_value, $encrypted_value );
+		$this->assertSame( $raw_value, Encryptor::decrypt( $encrypted_value ) );
+	}
+
+	/**
+	 * Tests that invalid base64 input is treated as an already plain value.
+	 */
+	public function test_decrypt_returns_raw_value_when_value_is_not_base64(): void {
+		$raw_value = 'not encrypted % value';
+
+		$this->assertSame( $raw_value, Encryptor::decrypt( $raw_value ) );
+	}
+
+	/**
+	 * Tests that decrypting tampered encrypted data fails.
+	 */
+	public function test_decrypt_returns_false_when_payload_is_tampered(): void {
+		$encrypted_value = Encryptor::encrypt( 'secret value' );
+
+		$this->assertIsString( $encrypted_value );
+
+		$decoded_value = base64_decode( $encrypted_value, true );
+
+		$this->assertIsString( $decoded_value );
+
+		$tampered_value = base64_encode( $decoded_value . 'tampered' );
+
+		$this->assertFalse( Encryptor::decrypt( $tampered_value ) );
+	}
+}

--- a/tests/phpunit/Unit/UtilsTest.php
+++ b/tests/phpunit/Unit/UtilsTest.php
@@ -9,11 +9,9 @@ declare( strict_types = 1 );
 
 namespace OneMedia\Tests\Unit;
 
+use OneMedia\Tests\TestCase;
 use OneMedia\Utils;
 use PHPUnit\Framework\Attributes\CoversClass;
-use rtCamp\OneMedia\Tests\TestCase;
-
-require_once dirname( __DIR__ ) . '/TestCase.php';
 
 /**
  * @covers \OneMedia\Utils
@@ -71,7 +69,7 @@ final class UtilsTest extends TestCase {
 		);
 
 		$this->assertStringContainsString( '<select name="onemedia_sync_status"', $content );
-		$this->assertMatchesRegularExpression( '/<option value="sync"\\s+selected=\'selected\'>Synced<\\/option>/', $content );
+		$this->assertMatchesRegularExpression( '/<option\\b[^>]*\\bvalue=([\'"])sync\\1[^>]*\\bselected(?:=([\'"])selected\\2)?[^>]*>/', $content );
 		$this->assertStringContainsString( 'name="onemedia_sync_nonce"', $content );
 	}
 
@@ -79,12 +77,6 @@ final class UtilsTest extends TestCase {
 	 * Tests that missing templates return an empty string.
 	 */
 	public function test_get_template_content_returns_empty_string_for_missing_template(): void {
-		$initial_ob_level = ob_get_level();
-
 		$this->assertSame( '', Utils::get_template_content( 'missing/template' ) );
-
-		while ( ob_get_level() > $initial_ob_level ) {
-			ob_end_clean();
-		}
 	}
 }

--- a/tests/phpunit/Unit/UtilsTest.php
+++ b/tests/phpunit/Unit/UtilsTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Tests for utility helpers.
+ *
+ * @package OneMedia\Tests\Unit
+ */
+
+declare( strict_types = 1 );
+
+namespace OneMedia\Tests\Unit;
+
+use OneMedia\Utils;
+use PHPUnit\Framework\Attributes\CoversClass;
+use rtCamp\OneMedia\Tests\TestCase;
+
+require_once dirname( __DIR__ ) . '/TestCase.php';
+
+/**
+ * @covers \OneMedia\Utils
+ */
+#[CoversClass( Utils::class )]
+final class UtilsTest extends TestCase {
+	/**
+	 * Tests that HTML entities in file names are decoded.
+	 */
+	public function test_decode_filename_decodes_html_entities(): void {
+		$this->assertSame(
+			'Brand "Logo" & Icon\'s.png',
+			Utils::decode_filename( 'Brand &quot;Logo&quot; &amp; Icon&#039;s.png' )
+		);
+	}
+
+	/**
+	 * Tests that supported mime types only include OneMedia image mime types.
+	 */
+	public function test_get_supported_mime_types_filters_to_onemedia_image_mimes(): void {
+		add_filter( // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes -- Test fixture covers OneMedia's supported mime filtering.
+			'upload_mimes',
+			static function ( array $mimes ): array {
+				$mimes['pdf']     = 'application/pdf';
+				$mimes['webp']    = 'image/webp';
+				$mimes['custom']  = 'image/custom';
+				$mimes['svg']     = 'image/svg+xml';
+				$mimes['svgz']    = 'image/svg+xml';
+				$mimes['notreal'] = 'application/x-not-real';
+
+				return $mimes;
+			}
+		);
+
+		$supported_mimes = Utils::get_supported_mime_types();
+
+		$this->assertSame( 'image/jpeg', $supported_mimes['jpg|jpeg|jpe'] );
+		$this->assertSame( 'image/png', $supported_mimes['png'] );
+		$this->assertSame( 'image/webp', $supported_mimes['webp'] );
+		$this->assertSame( 'image/svg+xml', $supported_mimes['svg'] );
+		$this->assertArrayNotHasKey( 'pdf', $supported_mimes );
+		$this->assertArrayNotHasKey( 'custom', $supported_mimes );
+		$this->assertArrayNotHasKey( 'notreal', $supported_mimes );
+	}
+
+	/**
+	 * Tests that existing templates render and receive variables.
+	 */
+	public function test_get_template_content_renders_existing_template_with_variables(): void {
+		$content = Utils::get_template_content(
+			'brand-site/sync-status',
+			[
+				'sync_status' => 'sync',
+			]
+		);
+
+		$this->assertStringContainsString( '<select name="onemedia_sync_status"', $content );
+		$this->assertMatchesRegularExpression( '/<option value="sync"\\s+selected=\'selected\'>Synced<\\/option>/', $content );
+		$this->assertStringContainsString( 'name="onemedia_sync_nonce"', $content );
+	}
+
+	/**
+	 * Tests that missing templates return an empty string.
+	 */
+	public function test_get_template_content_returns_empty_string_for_missing_template(): void {
+		$initial_ob_level = ob_get_level();
+
+		$this->assertSame( '', Utils::get_template_content( 'missing/template' ) );
+
+		while ( ob_get_level() > $initial_ob_level ) {
+			ob_end_clean();
+		}
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"noEmit": true,
 		"rootDir": ".",
 		"baseUrl": ".",
+		"types": [ "jest", "node", "@testing-library/jest-dom" ],
 		"outDir": "./build",
 		"paths": {
 			"@/*": [ "./assets/src/*" ]


### PR DESCRIPTION
## What

Added JS and PHP unit testing.

## How

This PR changes only for unit testing in the JS and PHP parts.

## Testing Instructions

PHP: 
```
npm run wp-env:test -- start --xdebug=coverage
npm run test:php -- tests/phpunit/Unit
```
JS: 
```
npm run test:js
```

## Checklist

<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
[Development Guidelines](../docs/DEVELOPMENT.md)
-->

- [x] I have read the [Contribution Guidelines](https://github.com/rtCamp/OneMedia/blob/main/docs/CONTRIBUTING.md).
- [x] I have read the [Development Guidelines](https://github.com/rtCamp/OneMedia/blob/main/docs/DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (ESLint etc.).
- [ ] My code has detailed inline documentation.
- [ ] I have updated the project documentation as needed.
- [ ] I have added a changeset for this PR using `npm run changeset`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22OneMedia%20Demo%22%2C%22description%22%3A%22%40Todo%3A%20Your%20demo%20description%20goes%20here.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22plugin%22%2C%22skeleton%22%2C%22development%22%2C%22enterprise%22%5D%7D%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fonemedia%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-100-a7505ba537358e3c514c98096fa40f98db5fc5bc.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->