### PR TITLE
chore: Add unit tests for MediaSharing and REST modules - Phase 3

### DIFF
--- a/tests/phpunit/Unit/Modules/MediaSharing/AdminTest.php
+++ b/tests/phpunit/Unit/Modules/MediaSharing/AdminTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Tests for the MediaSharing\Admin class.
+ *
+ * @package OneMedia\Tests\Unit\Modules\MediaSharing
+ */
+
+declare( strict_types = 1 );
+
+namespace OneMedia\Tests\Unit\Modules\MediaSharing;
+
+use OneMedia\Modules\Core\Assets;
+use OneMedia\Modules\MediaSharing\Admin;
+use OneMedia\Modules\Settings\Settings;
+use OneMedia\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Tests for the MediaSharing\Admin class.
+ */
+#[CoversClass( Admin::class )]
+final class AdminTest extends TestCase {
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function tearDown(): void {
+		delete_option( Settings::OPTION_SITE_TYPE );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests no errors on hook registration.
+	 */
+	public function test_register_hooks_adds_expected_hooks(): void {
+		$admin = new Admin();
+		$admin->register_hooks();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests add_submenu returns early when the site is not governing.
+	 */
+	public function test_add_submenu_returns_early_when_not_governing(): void {
+		update_option( Settings::OPTION_SITE_TYPE, Settings::SITE_TYPE_CONSUMER );
+
+		$admin = new Admin();
+		$admin->add_submenu();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests screen_callback outputs the media sharing mount point.
+	 */
+	public function test_screen_callback_outputs_expected_html(): void {
+		$admin = new Admin();
+
+		ob_start();
+		$admin->screen_callback();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'onemedia-media-sharing', (string) $output );
+	}
+
+	/**
+	 * Tests enqueue_scripts returns early for non-OneMedia admin pages.
+	 */
+	public function test_enqueue_scripts_returns_early_for_non_onemedia_hook(): void {
+		$admin = new Admin();
+		$admin->enqueue_scripts( 'plugins.php' );
+
+		$this->assertFalse( wp_script_is( Assets::MEDIA_SHARING_SCRIPT_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * Tests add_help_tabs returns early without a matching current screen.
+	 */
+	public function test_add_help_tabs_returns_early_for_non_matching_screen(): void {
+		$admin = new Admin();
+		$admin->add_help_tabs();
+
+		$this->assertTrue( true );
+	}
+}

--- a/tests/phpunit/Unit/Modules/MediaSharing/AttachmentTest.php
+++ b/tests/phpunit/Unit/Modules/MediaSharing/AttachmentTest.php
@@ -105,4 +105,25 @@ final class AttachmentTest extends TestCase {
 	public function test_get_sync_attachment_versions_returns_empty_when_not_set(): void {
 		$this->assertSame( [], Attachment::get_sync_attachment_versions( $this->attachment_id ) );
 	}
+
+	/**
+	 * Tests update_sync_attachment_versions returns false for empty versions.
+	 */
+	public function test_update_sync_attachment_versions_returns_false_for_empty_versions(): void {
+		$this->assertFalse( Attachment::update_sync_attachment_versions( $this->attachment_id, [] ) );
+	}
+
+	/**
+	 * Tests health_check_attachment_brand_sites returns an error payload for invalid attachment IDs.
+	 */
+	public function test_health_check_attachment_brand_sites_returns_error_payload_for_invalid_attachment_id(): void {
+		$this->assertSame(
+			[
+				'success'      => false,
+				'failed_sites' => [],
+				'message'      => 'Invalid attachment ID.',
+			],
+			Attachment::health_check_attachment_brand_sites( null )
+		);
+	}
 }

--- a/tests/phpunit/Unit/Modules/MediaSharing/MediaActionsTest.php
+++ b/tests/phpunit/Unit/Modules/MediaSharing/MediaActionsTest.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Tests for the MediaSharing\MediaActions class.
+ *
+ * @package OneMedia\Tests\Unit\Modules\MediaSharing
+ */
+
+declare( strict_types = 1 );
+
+namespace OneMedia\Tests\Unit\Modules\MediaSharing;
+
+use OneMedia\Modules\MediaSharing\Attachment;
+use OneMedia\Modules\MediaSharing\MediaActions;
+use OneMedia\Modules\Settings\Settings;
+use OneMedia\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Tests for the MediaSharing\MediaActions class.
+ */
+#[CoversClass( MediaActions::class )]
+final class MediaActionsTest extends TestCase {
+	/**
+	 * Attachment post for testing.
+	 *
+	 * @var \WP_Post
+	 */
+	private \WP_Post $attachment;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->attachment = get_post( self::factory()->attachment->create() );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function tearDown(): void {
+		delete_option( Settings::OPTION_SITE_TYPE );
+		delete_option( Settings::BRAND_SITES_SYNCED_MEDIA );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests no errors on hook registration.
+	 */
+	public function test_register_hooks_adds_expected_hooks(): void {
+		$actions = new MediaActions();
+		$actions->register_hooks();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests add_replace_media_button returns unchanged fields on consumer sites.
+	 */
+	public function test_add_replace_media_button_returns_fields_on_consumer_site(): void {
+		update_option( Settings::OPTION_SITE_TYPE, Settings::SITE_TYPE_CONSUMER );
+
+		$actions     = new MediaActions();
+		$form_fields = [ 'title' => [ 'label' => 'Title' ] ];
+
+		$this->assertSame( $form_fields, $actions->add_replace_media_button( $form_fields, $this->attachment ) );
+	}
+
+	/**
+	 * Tests add_replace_media_button returns unchanged fields for non-synced media.
+	 */
+	public function test_add_replace_media_button_returns_fields_for_non_synced_media(): void {
+		$actions     = new MediaActions();
+		$form_fields = [ 'title' => [ 'label' => 'Title' ] ];
+
+		$this->assertSame( $form_fields, $actions->add_replace_media_button( $form_fields, $this->attachment ) );
+	}
+
+	/**
+	 * Tests add_replace_media_button adds the replace media field for synced governing media.
+	 */
+	public function test_add_replace_media_button_adds_field_for_synced_media(): void {
+		update_option( Settings::OPTION_SITE_TYPE, Settings::SITE_TYPE_GOVERNING );
+		Attachment::set_is_synced( $this->attachment->ID, true );
+
+		$actions = new MediaActions();
+		$result  = $actions->add_replace_media_button( [], $this->attachment );
+
+		$this->assertArrayHasKey( 'replace_media', $result );
+		$this->assertSame( 'Replace Media', $result['replace_media']['label'] );
+		$this->assertStringContainsString( 'replace-media-react-container', $result['replace_media']['html'] );
+	}
+
+	/**
+	 * Tests remove_sync_meta returns early when there is no synced media option.
+	 */
+	public function test_remove_sync_meta_returns_early_without_synced_media_option(): void {
+		Attachment::set_is_synced( $this->attachment->ID, true );
+
+		$actions = new MediaActions();
+		$actions->remove_sync_meta( $this->attachment->ID );
+
+		$this->assertTrue( Attachment::is_sync_attachment( $this->attachment->ID ) );
+	}
+
+	/**
+	 * Tests remove_sync_meta removes local sync metadata and option mapping.
+	 */
+	public function test_remove_sync_meta_removes_local_sync_data(): void {
+		Attachment::set_is_synced( $this->attachment->ID, true );
+		update_post_meta(
+			$this->attachment->ID,
+			Attachment::SYNC_SITES_POSTMETA_KEY,
+			[
+				[
+					'site' => 'https://brand.example',
+					'id'   => 123,
+				],
+			]
+		);
+		update_option(
+			Settings::BRAND_SITES_SYNCED_MEDIA,
+			[
+				$this->attachment->ID => [ 'https://brand.example' => 123 ],
+			]
+		);
+
+		$actions = new MediaActions();
+		$actions->remove_sync_meta( $this->attachment->ID );
+
+		$this->assertFalse( Attachment::is_sync_attachment( $this->attachment->ID ) );
+		$this->assertSame( '', get_post_meta( $this->attachment->ID, Attachment::SYNC_SITES_POSTMETA_KEY, true ) );
+		$this->assertSame( [], get_option( Settings::BRAND_SITES_SYNCED_MEDIA ) );
+	}
+
+	/**
+	 * Tests sanitize_file_input returns an error when no file is provided.
+	 */
+	public function test_sanitize_file_input_returns_error_for_missing_file(): void {
+		$actions = new MediaActions();
+		$result  = $actions->sanitize_file_input( null );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_input', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests sanitize_file_input returns an error for unsupported mime types.
+	 */
+	public function test_sanitize_file_input_returns_error_for_invalid_file_type(): void {
+		$actions = new MediaActions();
+		$result  = $actions->sanitize_file_input(
+			[
+				'name'     => 'document.pdf',
+				'type'     => 'application/pdf',
+				'tmp_name' => '/tmp/document.pdf',
+				'error'    => 0,
+				'size'     => 100,
+			]
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_file_type', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests sanitize_file_input returns sanitized supported file data.
+	 */
+	public function test_sanitize_file_input_returns_sanitized_file_data(): void {
+		$actions = new MediaActions();
+		$result  = $actions->sanitize_file_input(
+			[
+				'name'          => 'Test &amp; Image.jpg',
+				'type'          => 'image/jpeg',
+				'tmp_name'      => '/tmp/test-image.jpg',
+				'error'         => 0,
+				'size'          => '100',
+				'attachment_id' => '12',
+				'url'           => 'https://example.com/test-image.jpg',
+				'alt'           => 'Alt text',
+				'caption'       => 'Caption text',
+			]
+		);
+
+		$this->assertSame(
+			[
+				'name'          => 'Test-amp-Image.jpg',
+				'type'          => 'image/jpeg',
+				'tmp_name'      => '/tmp/test-image.jpg',
+				'error'         => 0,
+				'size'          => 100,
+				'attachment_id' => 12,
+				'url'           => 'https://example.com/test-image.jpg',
+				'alt'           => 'Alt text',
+				'caption'       => 'Caption text',
+			],
+			$result
+		);
+	}
+
+	/**
+	 * Tests update_attachment returns an error for invalid attachments.
+	 */
+	public function test_update_attachment_returns_error_for_invalid_attachment(): void {
+		$actions = new MediaActions();
+		$result  = $actions->update_attachment( 0, [] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_attachment', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests restore_attachment_version returns an error when no version history exists.
+	 */
+	public function test_restore_attachment_version_returns_error_without_version_history(): void {
+		$actions = new MediaActions();
+		$result  = $actions->restore_attachment_version(
+			$this->attachment->ID,
+			[
+				'path' => '/tmp/missing.jpg',
+			]
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'no_version_history', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests add_sync_meta returns the original response when attachment ID is missing.
+	 */
+	public function test_add_sync_meta_returns_response_when_attachment_id_missing(): void {
+		$actions  = new MediaActions();
+		$response = [ 'id' => 0 ];
+
+		$this->assertSame( $response, $actions->add_sync_meta( $response, new \stdClass() ) );
+	}
+
+	/**
+	 * Tests add_sync_meta adds the sync status for attachment responses.
+	 */
+	public function test_add_sync_meta_adds_sync_status(): void {
+		Attachment::set_is_synced( $this->attachment->ID, true );
+
+		$actions = new MediaActions();
+
+		$this->assertSame(
+			[
+				'id'               => $this->attachment->ID,
+				'is_onemedia_sync' => true,
+			],
+			$actions->add_sync_meta( [ 'id' => $this->attachment->ID ], $this->attachment )
+		);
+	}
+}

--- a/tests/phpunit/Unit/Modules/MediaSharing/MediaProtectionTest.php
+++ b/tests/phpunit/Unit/Modules/MediaSharing/MediaProtectionTest.php
@@ -36,6 +36,15 @@ final class MediaProtectionTest extends TestCase {
 	}
 
 	/**
+	 * {@inheritDoc}
+	 */
+	protected function tearDown(): void {
+		delete_transient( 'onemedia_delete_notice' );
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Tests no errors on hook registration.
 	 */
 	public function test_register_hooks_adds_expected_hooks(): void {
@@ -43,6 +52,35 @@ final class MediaProtectionTest extends TestCase {
 		$protection->register_hooks();
 
 		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests show_deletion_notice outputs nothing when the transient is missing.
+	 */
+	public function test_show_deletion_notice_outputs_nothing_when_transient_missing(): void {
+		$protection = new MediaProtection();
+
+		ob_start();
+		$protection->show_deletion_notice();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Tests show_deletion_notice outputs a notice when the transient is set.
+	 */
+	public function test_show_deletion_notice_outputs_notice_when_transient_is_set(): void {
+		set_transient( 'onemedia_delete_notice', true );
+
+		$protection = new MediaProtection();
+
+		ob_start();
+		$protection->show_deletion_notice();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'notice-error', (string) $output );
+		$this->assertFalse( get_transient( 'onemedia_delete_notice' ) );
 	}
 
 	/**

--- a/tests/phpunit/Unit/Modules/MediaSharing/MediaReplacementTest.php
+++ b/tests/phpunit/Unit/Modules/MediaSharing/MediaReplacementTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Tests for the MediaSharing\MediaReplacement class.
+ *
+ * @package OneMedia\Tests\Unit\Modules\MediaSharing
+ */
+
+declare( strict_types = 1 );
+
+namespace OneMedia\Tests\Unit\Modules\MediaSharing;
+
+use OneMedia\Modules\MediaSharing\MediaReplacement;
+use OneMedia\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Tests for the MediaSharing\MediaReplacement class.
+ */
+#[CoversClass( MediaReplacement::class )]
+final class MediaReplacementTest extends TestCase {
+	/**
+	 * Tests replace_image_across_all_post_types updates post content and matching post meta.
+	 */
+	public function test_replace_image_across_all_post_types_updates_content_and_meta(): void {
+		$attachment_id = 987654;
+		$post_id       = self::factory()->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_content' => sprintf(
+					'<figure class="wp-block-image"><img src="https://example.com/old.jpg" srcset="old-2x.jpg 2x" sizes="100vw" alt="Old alt" class="wp-image-%d" /><figcaption>Old caption</figcaption></figure>',
+					$attachment_id
+				),
+			]
+		);
+		update_post_meta(
+			$post_id,
+			'onemedia_test_image_html',
+			sprintf(
+				'<img src="https://example.com/meta-old.jpg" alt="Meta old alt" class="wp-image-%d" />',
+				$attachment_id
+			)
+		);
+
+		MediaReplacement::replace_image_across_all_post_types(
+			$attachment_id,
+			'https://cdn.example.com/new.jpg',
+			'New alt',
+			'New caption'
+		);
+
+		$content = get_post_field( 'post_content', $post_id );
+		$meta    = get_post_meta( $post_id, 'onemedia_test_image_html', true );
+
+		$this->assertStringContainsString( 'src="https://cdn.example.com/new.jpg"', $content );
+		$this->assertStringContainsString( 'alt="New alt"', $content );
+		$this->assertStringContainsString( 'New caption', $content );
+		$this->assertStringNotContainsString( 'srcset=', $content );
+		$this->assertStringNotContainsString( 'sizes=', $content );
+		$this->assertStringContainsString( 'src="https://cdn.example.com/new.jpg"', $meta );
+		$this->assertStringContainsString( 'alt="New alt"', $meta );
+	}
+}

--- a/tests/phpunit/Unit/Modules/MediaSharing/UserInterfaceTest.php
+++ b/tests/phpunit/Unit/Modules/MediaSharing/UserInterfaceTest.php
@@ -62,6 +62,49 @@ final class UserInterfaceTest extends TestCase {
 	}
 
 	/**
+	 * Tests render_sync_column outputs the synced badge for synced attachments.
+	 */
+	public function test_render_sync_column_outputs_synced_badge(): void {
+		Attachment::set_is_synced( $this->attachment->ID, true );
+
+		$ui = new UserInterface();
+
+		ob_start();
+		$ui->render_sync_column( 'onemedia_sync_status', $this->attachment->ID );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'onemedia-sync-badge', (string) $output );
+		$this->assertStringContainsString( 'Synced', (string) $output );
+	}
+
+	/**
+	 * Tests render_sync_column outputs the not-synced badge for non-synced attachments.
+	 */
+	public function test_render_sync_column_outputs_not_synced_badge(): void {
+		$ui = new UserInterface();
+
+		ob_start();
+		$ui->render_sync_column( 'onemedia_sync_status', $this->attachment->ID );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'dashicons-no', (string) $output );
+		$this->assertStringContainsString( 'Not synced', (string) $output );
+	}
+
+	/**
+	 * Tests render_sync_column returns early for other columns.
+	 */
+	public function test_render_sync_column_returns_early_for_other_column(): void {
+		$ui = new UserInterface();
+
+		ob_start();
+		$ui->render_sync_column( 'title', $this->attachment->ID );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
 	 * Tests filter_media_row_actions removes delete action for synced attachment.
 	 */
 	public function test_filter_media_row_actions_removes_delete_for_synced(): void {

--- a/tests/phpunit/Unit/Modules/Rest/AbstractRestControllerTest.php
+++ b/tests/phpunit/Unit/Modules/Rest/AbstractRestControllerTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Tests for the Rest\Abstract_REST_Controller class.
+ *
+ * @package OneMedia\Tests\Unit\Modules\Rest
+ */
+
+declare( strict_types = 1 );
+
+namespace OneMedia\Tests\Unit\Modules\Rest;
+
+use OneMedia\Modules\Rest\Abstract_REST_Controller;
+use OneMedia\Modules\Settings\Settings;
+use OneMedia\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WP_REST_Request;
+
+/**
+ * Test double for the abstract REST controller.
+ */
+final class AbstractRestControllerTestDouble extends Abstract_REST_Controller {
+}
+
+/**
+ * Tests for the Rest\Abstract_REST_Controller class.
+ */
+#[CoversClass( Abstract_REST_Controller::class )]
+final class AbstractRestControllerTest extends TestCase {
+	/**
+	 * Controller under test.
+	 *
+	 * @var \OneMedia\Tests\Unit\Modules\Rest\AbstractRestControllerTestDouble
+	 */
+	private AbstractRestControllerTestDouble $controller;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->controller = new AbstractRestControllerTestDouble();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function tearDown(): void {
+		wp_set_current_user( 0 );
+		delete_option( Settings::OPTION_SITE_TYPE );
+		delete_option( Settings::OPTION_CONSUMER_API_KEY );
+		delete_option( Settings::OPTION_CONSUMER_PARENT_SITE_URL );
+		delete_option( Settings::OPTION_GOVERNING_SHARED_SITES );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests no errors on hook registration.
+	 */
+	public function test_register_hooks_adds_rest_api_init_action(): void {
+		$this->controller->register_hooks();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests same-origin requests use the current user's manage_options capability.
+	 */
+	public function test_check_api_permissions_returns_true_for_local_admin_request(): void {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$request = new WP_REST_Request( 'GET', '/onemedia/v1/site-type' );
+		$request->set_header( 'Origin', get_site_url() );
+
+		$this->assertTrue( $this->controller->check_api_permissions( $request ) );
+	}
+
+	/**
+	 * Tests remote requests without a token are rejected.
+	 */
+	public function test_check_api_permissions_returns_false_without_token_for_remote_origin(): void {
+		$request = new WP_REST_Request( 'GET', '/onemedia/v1/health-check' );
+		$request->set_header( 'Origin', 'https://brand-one.example' );
+
+		$this->assertFalse( $this->controller->check_api_permissions( $request ) );
+	}
+
+	/**
+	 * Tests remote requests with an invalid token are rejected.
+	 */
+	public function test_check_api_permissions_returns_false_for_invalid_token(): void {
+		update_option( Settings::OPTION_SITE_TYPE, Settings::SITE_TYPE_GOVERNING );
+		Settings::set_shared_sites(
+			[
+				[
+					'id'      => 'brand-1',
+					'name'    => 'Brand One',
+					'url'     => 'https://brand-one.example',
+					'api_key' => 'brand-one-key',
+				],
+			]
+		);
+
+		$request = new WP_REST_Request( 'GET', '/onemedia/v1/health-check' );
+		$request->set_header( 'Origin', 'https://brand-one.example' );
+		$request->set_header( 'X-OneMedia-Token', 'wrong-token' );
+
+		$this->assertFalse( $this->controller->check_api_permissions( $request ) );
+	}
+
+	/**
+	 * Tests governing sites accept a valid child-site token.
+	 */
+	public function test_check_api_permissions_returns_true_for_governing_site_with_valid_token(): void {
+		update_option( Settings::OPTION_SITE_TYPE, Settings::SITE_TYPE_GOVERNING );
+		Settings::set_shared_sites(
+			[
+				[
+					'id'      => 'brand-1',
+					'name'    => 'Brand One',
+					'url'     => 'https://brand-one.example',
+					'api_key' => 'brand-one-key',
+				],
+			]
+		);
+
+		$request = new WP_REST_Request( 'GET', '/onemedia/v1/shared-sites' );
+		$request->set_header( 'Origin', 'https://brand-one.example' );
+		$request->set_header( 'X-OneMedia-Token', 'brand-one-key' );
+
+		$this->assertTrue( $this->controller->check_api_permissions( $request ) );
+	}
+
+	/**
+	 * Tests consumer health-check requests store the governing site URL.
+	 */
+	public function test_check_api_permissions_sets_parent_site_on_health_check_for_consumer(): void {
+		update_option( Settings::OPTION_SITE_TYPE, Settings::SITE_TYPE_CONSUMER );
+		$api_key = Settings::get_api_key();
+
+		$request = new WP_REST_Request( 'GET', '/onemedia/v1/health-check' );
+		$request->set_header( 'Origin', 'https://governing.example' );
+		$request->set_header( 'X-OneMedia-Token', $api_key );
+
+		$this->assertTrue( $this->controller->check_api_permissions( $request ) );
+		$this->assertSame( 'https://governing.example/', Settings::get_parent_site_url() );
+	}
+
+	/**
+	 * Tests consumer non-health-check requests must match the saved governing site origin.
+	 */
+	public function test_check_api_permissions_rejects_non_health_check_when_origin_does_not_match_parent(): void {
+		update_option( Settings::OPTION_SITE_TYPE, Settings::SITE_TYPE_CONSUMER );
+		Settings::set_parent_site_url( 'https://expected-governing.example' );
+		$api_key = Settings::get_api_key();
+
+		$request = new WP_REST_Request( 'GET', '/onemedia/v1/shared-sites' );
+		$request->set_header( 'Origin', 'https://different-governing.example' );
+		$request->set_header( 'X-OneMedia-Token', $api_key );
+
+		$this->assertFalse( $this->controller->check_api_permissions( $request ) );
+	}
+}

--- a/tests/phpunit/Unit/Modules/Rest/BasicOptionsControllerTest.php
+++ b/tests/phpunit/Unit/Modules/Rest/BasicOptionsControllerTest.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Tests for the Rest\Basic_Options_Controller class.
+ *
+ * @package OneMedia\Tests\Unit\Modules\Rest
+ */
+
+declare( strict_types = 1 );
+
+namespace OneMedia\Tests\Unit\Modules\Rest;
+
+use OneMedia\Modules\Rest\Basic_Options_Controller;
+use OneMedia\Modules\Settings\Settings;
+use OneMedia\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WP_REST_Request;
+
+/**
+ * Tests for the Rest\Basic_Options_Controller class.
+ */
+#[CoversClass( Basic_Options_Controller::class )]
+final class BasicOptionsControllerTest extends TestCase {
+	/**
+	 * Controller under test.
+	 *
+	 * @var \OneMedia\Modules\Rest\Basic_Options_Controller
+	 */
+	private Basic_Options_Controller $controller;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->controller = new Basic_Options_Controller();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function tearDown(): void {
+		delete_option( Settings::OPTION_SITE_TYPE );
+		delete_option( Settings::OPTION_CONSUMER_API_KEY );
+		delete_option( Settings::OPTION_CONSUMER_PARENT_SITE_URL );
+		delete_option( Settings::OPTION_GOVERNING_SHARED_SITES );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests no errors on hook registration.
+	 */
+	public function test_register_hooks_adds_rest_api_init_action(): void {
+		$this->controller->register_hooks();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests get_site_type returns the current option value.
+	 */
+	public function test_get_site_type_returns_current_option(): void {
+		update_option( Settings::OPTION_SITE_TYPE, Settings::SITE_TYPE_CONSUMER );
+
+		$response = $this->controller->get_site_type();
+
+		$this->assertSame(
+			[
+				'success'   => true,
+				'site_type' => Settings::SITE_TYPE_CONSUMER,
+			],
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Tests set_site_type updates the option and returns the saved value.
+	 */
+	public function test_set_site_type_updates_option_and_returns_response(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/site-type' );
+		$request->set_param( 'site_type', Settings::SITE_TYPE_GOVERNING );
+
+		$response = $this->controller->set_site_type( $request );
+
+		$this->assertSame(
+			[
+				'success'   => true,
+				'site_type' => Settings::SITE_TYPE_GOVERNING,
+			],
+			$response->get_data()
+		);
+		$this->assertSame( Settings::SITE_TYPE_GOVERNING, get_option( Settings::OPTION_SITE_TYPE ) );
+	}
+
+	/**
+	 * Tests get_shared_sites returns array values from the stored shared sites.
+	 */
+	public function test_get_shared_sites_returns_array_values(): void {
+		Settings::set_shared_sites(
+			[
+				[
+					'id'      => 'brand-1',
+					'name'    => 'Brand One',
+					'url'     => 'https://brand-one.example',
+					'api_key' => 'brand-one-key',
+				],
+			]
+		);
+
+		$response = $this->controller->get_shared_sites();
+
+		$this->assertSame(
+			[
+				'success'      => true,
+				'shared_sites' => [
+					[
+						'api_key' => 'brand-one-key',
+						'id'      => 'brand-1',
+						'name'    => 'Brand One',
+						'url'     => 'https://brand-one.example/',
+					],
+				],
+			],
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Tests set_shared_sites rejects duplicate URLs.
+	 */
+	public function test_set_shared_sites_returns_error_for_duplicate_urls(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/shared-sites' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'shared_sites' => [
+						[
+							'name' => 'Brand One',
+							'url'  => 'https://brand-one.example',
+						],
+						[
+							'name' => 'Brand One Duplicate',
+							'url'  => 'https://brand-one.example',
+						],
+					],
+				]
+			)
+		);
+
+		$result = $this->controller->set_shared_sites( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'duplicate_site_url', $result->get_error_code() );
+		$this->assertSame( [ 'status' => 400 ], $result->get_error_data() );
+	}
+
+	/**
+	 * Tests set_shared_sites stores sites and generates missing IDs.
+	 */
+	public function test_set_shared_sites_stores_sites_and_generates_missing_ids(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/shared-sites' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'shared_sites' => [
+						[
+							'name'    => 'Brand One',
+							'url'     => 'https://brand-one.example',
+							'api_key' => 'brand-one-key',
+						],
+					],
+				]
+			)
+		);
+
+		$response = $this->controller->set_shared_sites( $request );
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$this->assertCount( 1, $data['shared_sites'] );
+		$this->assertMatchesRegularExpression( '/^[0-9a-f-]{36}$/i', $data['shared_sites'][0]['id'] );
+		$this->assertSame( 'Brand One', Settings::get_shared_site_by_url( 'https://brand-one.example' )['name'] );
+	}
+
+	/**
+	 * Tests health_check returns the expected success payload.
+	 */
+	public function test_health_check_returns_success_response(): void {
+		$response = $this->controller->health_check();
+
+		$this->assertSame(
+			[
+				'success' => true,
+				'message' => 'Health check passed successfully.',
+			],
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Tests get_governing_site returns the stored parent site URL.
+	 */
+	public function test_get_governing_site_returns_parent_site_url(): void {
+		Settings::set_parent_site_url( 'https://governing.example' );
+
+		$response = $this->controller->get_governing_site();
+
+		$this->assertSame(
+			[
+				'success'            => true,
+				'governing_site_url' => 'https://governing.example/',
+			],
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Tests remove_governing_site deletes the stored parent site URL.
+	 */
+	public function test_remove_governing_site_deletes_parent_site_url(): void {
+		Settings::set_parent_site_url( 'https://governing.example' );
+
+		$response = $this->controller->remove_governing_site();
+
+		$this->assertSame(
+			[
+				'success' => true,
+				'message' => 'Governing site removed successfully.',
+			],
+			$response->get_data()
+		);
+		$this->assertFalse( get_option( Settings::OPTION_CONSUMER_PARENT_SITE_URL ) );
+	}
+
+	/**
+	 * Tests get_secret_key returns a generated key.
+	 */
+	public function test_get_secret_key_returns_current_key(): void {
+		$response = $this->controller->get_secret_key();
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$this->assertIsString( $data['secret_key'] );
+		$this->assertNotSame( '', $data['secret_key'] );
+		$this->assertSame( Settings::get_api_key(), $data['secret_key'] );
+	}
+
+	/**
+	 * Tests regenerate_secret_key returns a new key.
+	 */
+	public function test_regenerate_secret_key_returns_new_key(): void {
+		$old_key  = Settings::get_api_key();
+		$response = $this->controller->regenerate_secret_key();
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( 'Secret key regenerated successfully.', $data['message'] );
+		$this->assertNotSame( $old_key, $data['secret_key'] );
+		$this->assertSame( Settings::get_api_key(), $data['secret_key'] );
+	}
+
+	/**
+	 * Tests check_sites_connected returns an error for invalid attachment IDs.
+	 */
+	public function test_check_sites_connected_returns_error_for_invalid_attachment(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/check-sites-connected' );
+		$request->set_param( 'attachment_id', 0 );
+
+		$result = $this->controller->check_sites_connected( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_data', $result->get_error_code() );
+		$this->assertSame(
+			[
+				'status'  => 400,
+				'success' => false,
+			],
+			$result->get_error_data()
+		);
+	}
+
+	/**
+	 * Tests fetch_multisite_type returns single on a non-multisite install.
+	 */
+	public function test_fetch_multisite_type_returns_single(): void {
+		$this->assertSame( 'single', $this->controller->fetch_multisite_type() );
+	}
+
+	/**
+	 * Tests get_multisite_type returns the expected response payload.
+	 */
+	public function test_get_multisite_type_returns_response_payload(): void {
+		$response = $this->controller->get_multisite_type();
+
+		$this->assertSame(
+			[
+				'status'         => 500,
+				'multisite_type' => 'single',
+				'success'        => true,
+			],
+			$response->get_data()
+		);
+	}
+}

--- a/tests/phpunit/Unit/Modules/Rest/MediaSharingControllerTest.php
+++ b/tests/phpunit/Unit/Modules/Rest/MediaSharingControllerTest.php
@@ -1,0 +1,502 @@
+<?php
+/**
+ * Tests for the Rest\Media_Sharing_Controller class.
+ *
+ * @package OneMedia\Tests\Unit\Modules\Rest
+ */
+
+declare( strict_types = 1 );
+
+namespace OneMedia\Tests\Unit\Modules\Rest;
+
+use OneMedia\Modules\MediaSharing\Attachment;
+use OneMedia\Modules\Rest\Media_Sharing_Controller;
+use OneMedia\Modules\Settings\Settings;
+use OneMedia\Tests\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WP_REST_Request;
+
+/**
+ * Tests for the Rest\Media_Sharing_Controller class.
+ */
+#[CoversClass( Media_Sharing_Controller::class )]
+final class MediaSharingControllerTest extends TestCase {
+	/**
+	 * Controller under test.
+	 *
+	 * @var \OneMedia\Modules\Rest\Media_Sharing_Controller
+	 */
+	private Media_Sharing_Controller $controller;
+
+	/**
+	 * Attachment ID for testing.
+	 *
+	 * @var int
+	 */
+	private int $attachment_id;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->controller    = new Media_Sharing_Controller();
+		$this->attachment_id = self::factory()->attachment->create(
+			[
+				'post_mime_type' => 'image/jpeg',
+			]
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function tearDown(): void {
+		delete_option( Settings::OPTION_GOVERNING_SHARED_SITES );
+		delete_option( Settings::BRAND_SITES_SYNCED_MEDIA );
+		delete_option( Media_Sharing_Controller::ATTACHMENT_KEY_MAP_OPTION );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests no errors on hook registration.
+	 */
+	public function test_register_hooks_adds_rest_api_init_action(): void {
+		$this->controller->register_hooks();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests brand_sites_synced_media_callback returns an empty mapping when no data is stored.
+	 */
+	public function test_brand_sites_synced_media_callback_returns_empty_mapping(): void {
+		$response = $this->controller->brand_sites_synced_media_callback();
+
+		$this->assertSame(
+			[
+				'status'  => 200,
+				'data'    => [],
+				'success' => true,
+			],
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Tests brand_sites_synced_media_callback maps URLs to known and unknown site names.
+	 */
+	public function test_brand_sites_synced_media_callback_maps_site_names(): void {
+		Settings::set_shared_sites(
+			[
+				[
+					'id'      => 'brand-1',
+					'name'    => 'Brand One',
+					'url'     => 'https://brand-one.example',
+					'api_key' => 'brand-one-key',
+				],
+			]
+		);
+		update_option(
+			Settings::BRAND_SITES_SYNCED_MEDIA,
+			[
+				$this->attachment_id => [
+					'https://brand-one.example/' => 11,
+					'https://unknown.example/'   => 22,
+				],
+			]
+		);
+
+		$response = $this->controller->brand_sites_synced_media_callback();
+
+		$this->assertSame(
+			[
+				'status'  => 200,
+				'data'    => [
+					$this->attachment_id => [
+						'https://brand-one.example' => 'Brand One',
+						'https://unknown.example'   => 'Unknown Site',
+					],
+				],
+				'success' => true,
+			],
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Tests delete_media_metadata returns an error for invalid attachment IDs.
+	 */
+	public function test_delete_media_metadata_returns_error_for_invalid_attachment(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/delete-media-metadata' );
+		$request->set_param( 'attachment_id', 0 );
+
+		$result = $this->controller->delete_media_metadata( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_data', $result->get_error_code() );
+		$this->assertSame(
+			[
+				'status'  => 400,
+				'success' => false,
+			],
+			$result->get_error_data()
+		);
+	}
+
+	/**
+	 * Tests delete_media_metadata deletes sync meta for valid attachments.
+	 */
+	public function test_delete_media_metadata_deletes_sync_meta(): void {
+		Attachment::set_is_synced( $this->attachment_id, true );
+		update_post_meta( $this->attachment_id, Attachment::SYNC_SITES_POSTMETA_KEY, [ 'https://brand.example' => 12 ] );
+		update_post_meta( $this->attachment_id, Attachment::SYNC_STATUS_POSTMETA_KEY, Attachment::SYNC_STATUS_SYNC );
+
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/delete-media-metadata' );
+		$request->set_param( 'attachment_id', $this->attachment_id );
+
+		$response = $this->controller->delete_media_metadata( $request );
+
+		$this->assertSame(
+			[
+				'message' => 'Media metadata deleted successfully.',
+				'status'  => 200,
+				'success' => true,
+			],
+			$response->get_data()
+		);
+		$this->assertFalse( Attachment::is_sync_attachment( $this->attachment_id ) );
+		$this->assertSame( '', get_post_meta( $this->attachment_id, Attachment::SYNC_SITES_POSTMETA_KEY, true ) );
+		$this->assertSame( '', get_post_meta( $this->attachment_id, Attachment::SYNC_STATUS_POSTMETA_KEY, true ) );
+	}
+
+	/**
+	 * Tests update_media_files returns an error for invalid attachment IDs.
+	 */
+	public function test_update_media_files_returns_error_for_invalid_attachment(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/update-media' );
+		$request->set_param( 'attachment_id', 0 );
+
+		$result = $this->controller->update_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_data', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests update_media_files returns an error for invalid URLs.
+	 */
+	public function test_update_media_files_returns_error_for_invalid_url(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/update-media' );
+		$request->set_param( 'attachment_id', $this->attachment_id );
+		$request->set_param( 'attachment_url', 'not-a-url' );
+		$request->set_param( 'attachment_data', [ 'title' => 'Updated title' ] );
+
+		$result = $this->controller->update_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_data', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests update_media_files returns an error for invalid attachment data.
+	 */
+	public function test_update_media_files_returns_error_for_invalid_attachment_data(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/update-media' );
+		$request->set_param( 'attachment_id', $this->attachment_id );
+		$request->set_param( 'attachment_url', 'https://example.com/image.jpg' );
+		$request->set_param( 'attachment_data', [ 'title' => [ 'invalid' ] ] );
+
+		$result = $this->controller->update_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_data', $result->get_error_code() );
+		$this->assertSame(
+			[
+				'status'  => 400,
+				'success' => false,
+			],
+			$result->get_error_data()
+		);
+	}
+
+	/**
+	 * Tests get_media_files returns an empty successful response by default.
+	 */
+	public function test_get_media_files_returns_empty_response_by_default(): void {
+		$request = new WP_REST_Request( 'GET', '/onemedia/v1/media' );
+
+		$response = $this->controller->get_media_files( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 1, $data['page'] );
+		$this->assertSame( 10, $data['per_page'] );
+		$this->assertSame( 200, $data['status'] );
+		$this->assertTrue( $data['success'] );
+		$this->assertIsArray( $data['media_files'] );
+	}
+
+	/**
+	 * Tests sync_media_files validates brand sites.
+	 */
+	public function test_sync_media_files_returns_error_for_invalid_brand_sites(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/sync-media' );
+		$request->set_param( 'brand_sites', [] );
+
+		$result = $this->controller->sync_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_data', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests sync_media_files validates site URLs.
+	 */
+	public function test_sync_media_files_returns_error_for_invalid_site_url(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/sync-media' );
+		$request->set_param( 'brand_sites', [ 'not-a-url' ] );
+
+		$result = $this->controller->sync_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_site_url', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests sync_media_files validates sync option.
+	 */
+	public function test_sync_media_files_returns_error_for_invalid_sync_option(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/sync-media' );
+		$request->set_param( 'brand_sites', [ 'https://brand.test' ] );
+		$request->set_param( 'sync_option', 'invalid' );
+
+		$result = $this->controller->sync_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_sync_option', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests sync_media_files validates media details.
+	 */
+	public function test_sync_media_files_returns_error_for_invalid_media_details(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/sync-media' );
+		$request->set_param( 'brand_sites', [ 'https://brand.test' ] );
+		$request->set_param( 'sync_option', Attachment::SYNC_STATUS_SYNC );
+		$request->set_param( 'media_details', [] );
+
+		$result = $this->controller->sync_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_data', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests sync_media_files validates unsupported mime types before remote calls.
+	 */
+	public function test_sync_media_files_returns_error_for_invalid_mime_type(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/sync-media' );
+		$request->set_param( 'brand_sites', [ 'https://brand.test' ] );
+		$request->set_param( 'sync_option', Attachment::SYNC_STATUS_SYNC );
+		$request->set_param(
+			'media_details',
+			[
+				[
+					'id'        => $this->attachment_id,
+					'url'       => 'https://example.com/document.pdf',
+					'title'     => 'Document',
+					'mime_type' => 'application/pdf',
+				],
+			]
+		);
+
+		$result = $this->controller->sync_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_mime_type', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests add_media_files validates sync option.
+	 */
+	public function test_add_media_files_returns_error_for_invalid_sync_option(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/add-media' );
+		$request->set_param( 'sync_option', 'invalid' );
+
+		$result = $this->controller->add_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_sync_option', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests add_media_files validates media files.
+	 */
+	public function test_add_media_files_returns_error_for_invalid_media_files(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/add-media' );
+		$request->set_param( 'sync_option', Attachment::SYNC_STATUS_SYNC );
+		$request->set_param( 'media_files', [] );
+
+		$result = $this->controller->add_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_data', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests add_media_files validates individual media details.
+	 */
+	public function test_add_media_files_returns_error_for_invalid_media_details(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/add-media' );
+		$request->set_param( 'sync_option', Attachment::SYNC_STATUS_SYNC );
+		$request->set_param( 'media_files', [ [ 'id' => 0 ] ] );
+
+		$result = $this->controller->add_media_files( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_media_details', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests update_existing_attachment validates attachment IDs.
+	 */
+	public function test_update_existing_attachment_returns_error_for_invalid_attachment(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/update-existing-attachment' );
+		$request->set_param( 'attachment_id', 0 );
+
+		$result = $this->controller->update_existing_attachment( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_data', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests update_existing_attachment validates sync options.
+	 */
+	public function test_update_existing_attachment_returns_error_for_invalid_sync_option(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/update-existing-attachment' );
+		$request->set_param( 'attachment_id', $this->attachment_id );
+		$request->set_param( 'sync_option', 'invalid' );
+
+		$result = $this->controller->update_existing_attachment( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_data', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests update_existing_attachment marks an attachment as not synced.
+	 */
+	public function test_update_existing_attachment_marks_attachment_as_not_synced(): void {
+		Attachment::set_is_synced( $this->attachment_id, true );
+
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/update-existing-attachment' );
+		$request->set_param( 'attachment_id', $this->attachment_id );
+		$request->set_param( 'sync_option', Attachment::SYNC_STATUS_NO_SYNC );
+
+		$response = $this->controller->update_existing_attachment( $request );
+
+		$this->assertSame(
+			[
+				'attachment_id' => $this->attachment_id,
+				'message'       => 'Attachment marked as sync media.',
+				'status'        => 200,
+				'success'       => true,
+			],
+			$response->get_data()
+		);
+		$this->assertFalse( Attachment::is_sync_attachment( $this->attachment_id ) );
+	}
+
+	/**
+	 * Tests is_sync_attachment returns an error for invalid attachment IDs.
+	 */
+	public function test_is_sync_attachment_returns_error_for_invalid_attachment(): void {
+		$request = new WP_REST_Request( 'GET', '/onemedia/v1/is-sync-attachment' );
+		$request->set_param( 'attachment_id', 0 );
+
+		$result = $this->controller->is_sync_attachment( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_attachment_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests is_sync_attachment returns the attachment sync status.
+	 */
+	public function test_is_sync_attachment_returns_sync_status(): void {
+		Attachment::set_is_synced( $this->attachment_id, true );
+
+		$request = new WP_REST_Request( 'GET', '/onemedia/v1/is-sync-attachment' );
+		$request->set_param( 'attachment_id', $this->attachment_id );
+
+		$response = $this->controller->is_sync_attachment( $request );
+
+		$this->assertSame(
+			[
+				'attachment_id' => $this->attachment_id,
+				'is_sync'       => true,
+				'status'        => 200,
+				'success'       => true,
+			],
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * Tests sync_attachment_versions returns an error for invalid attachment IDs.
+	 */
+	public function test_sync_attachment_versions_returns_error_for_invalid_attachment(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/sync-attachment-versions' );
+		$request->set_param( 'attachment_id', 0 );
+
+		$result = $this->controller->sync_attachment_versions( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_attachment_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests sync_attachment_versions returns an error for non-synced attachments.
+	 */
+	public function test_sync_attachment_versions_returns_error_for_non_synced_attachment(): void {
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/sync-attachment-versions' );
+		$request->set_param( 'attachment_id', $this->attachment_id );
+
+		$result = $this->controller->sync_attachment_versions( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'not_sync_attachment', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests sync_attachment_versions returns stored versions for synced attachments.
+	 */
+	public function test_sync_attachment_versions_returns_versions_for_synced_attachment(): void {
+		$versions = [
+			[
+				'last_used' => 1000000,
+				'file'      => [ 'url' => 'https://example.com/image.jpg' ],
+			],
+		];
+		Attachment::set_is_synced( $this->attachment_id, true );
+		Attachment::update_sync_attachment_versions( $this->attachment_id, $versions );
+
+		$request = new WP_REST_Request( 'POST', '/onemedia/v1/sync-attachment-versions' );
+		$request->set_param( 'attachment_id', $this->attachment_id );
+
+		$response = $this->controller->sync_attachment_versions( $request );
+
+		$this->assertSame(
+			[
+				'attachment_id' => $this->attachment_id,
+				'versions'      => $versions,
+				'status'        => 200,
+				'success'       => true,
+			],
+			$response->get_data()
+		);
+	}
+}


### PR DESCRIPTION
## What

Adds unit test coverage for the OneMedia MediaSharing and REST modules.

## Why

This PR improves PHPUnit coverage for recently added MediaSharing and REST functionality, focusing on safe unit-testable paths and keeping the same test style used in the previous unit testing phases.

### Related Issue(s):

- Part of unit test coverage improvements for OneMedia.

## How

This PR adds and expands PHPUnit tests for:

- MediaSharing admin hook registration and safe admin output paths.
- MediaSharing attachment sync status, version, and health-check validation behavior.
- MediaSharing UI sync column rendering and row action filtering.
- MediaSharing media protection edit/delete guard behavior.
- MediaSharing media action helper methods and invalid request handling.
- Media replacement behavior for post content and attachment metadata.
- REST permission handling in the abstract REST controller.
- Basic options REST controller settings behavior.
- Media sharing REST controller validation and local metadata/update branches.

The tests avoid remote sync, upload, and AJAX exit-heavy success paths, and use WordPress test helpers/factories where possible.

## Testing Instructions

1. Check out this branch.
2. Start the test environment with coverage enabled:

   ```bash
   npm run wp-env:test -- start --xdebug=coverage
   ```

3. Run the PHP test suite:

   ```bash
   npm run test:php
   ```

4. Start the default wp-env environment if needed for linting:

   ```bash
   npm run wp-env -- start
   ```

5. Run PHP linting:

   ```bash
   npm run lint:php
   ```

Expected result:

- PHPUnit passes successfully.
- PHP linting passes successfully.

## Screenshots

N/A. This PR only adds automated test coverage.

## Additional Info

Last verified locally:

- `npm run test:php`
  - Passed: `153 tests, 257 assertions`
- `npm run lint:php`
  - Passed: `50 / 50 (100%)`
  - **This PR depends on `chore/php-unit-testing-phase-2` this branch so I set this PR base branch to `chore/php-unit-testing-phase-2.` once this PR https://github.com/rtCamp/onemedia/pull/130 merged we need to reabse the main branch with current PR branch**

## Checklist

- [ ] I have read the [Contribution Guidelines](https://github.com/rtCamp/OneMedia/blob/main/docs/CONTRIBUTING.md).
- [ ] I have read the [Development Guidelines](https://github.com/rtCamp/OneMedia/blob/main/docs/DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (ESLint etc.).
- [ ] My code has detailed inline documentation.
- [ ] I have updated the project documentation as needed.
- [ ] I have added a changeset for this PR using `npm run changeset`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22meta%22%3A%7B%22title%22%3A%22OneMedia%20Demo%22%2C%22description%22%3A%22%40Todo%3A%20Your%20demo%20description%20goes%20here.%22%2C%22author%22%3A%22rtCamp%22%2C%22categories%22%3A%5B%22plugin%22%2C%22skeleton%22%2C%22development%22%2C%22enterprise%22%5D%7D%2C%22landingPage%22%3A%22%2Fwp-admin%2Fplugins.php%22%2C%22preferredVersions%22%3A%7B%22php%22%3A%228.4%22%2C%22wp%22%3A%22latest%22%7D%2C%22features%22%3A%7B%22networking%22%3Atrue%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FrtCamp%2Fonemedia%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-137-d57e30b61ce51b236e4f22c11772d753e14d93f2.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->